### PR TITLE
Removed notMerged() call from postsQuery

### DIFF
--- a/app/Http/Controllers/Frontend/BoardController.php
+++ b/app/Http/Controllers/Frontend/BoardController.php
@@ -25,7 +25,7 @@ class BoardController extends Controller
             'commented' => 'comments',
         ];
 
-        $postsQuery = Post::where('board_id', $board->id)->notMerged();
+        $postsQuery = Post::where('board_id', $board->id);
         $statuses = Status::select('id')
                           ->inFrontend()
                           ->get();

--- a/app/Http/Controllers/Frontend/BoardController.php
+++ b/app/Http/Controllers/Frontend/BoardController.php
@@ -25,7 +25,7 @@ class BoardController extends Controller
             'commented' => 'comments',
         ];
 
-        $postsQuery = Post::where('board_id', $board->id);
+        $postsQuery = Post::query()->where('board_id', $board->id);
         $statuses = Status::select('id')
                           ->inFrontend()
                           ->get();


### PR DESCRIPTION
This PR fixes https://github.com/weDevsOfficial/ideabox/issues/29

<img width="1491" height="817" alt="Image" src="https://github.com/user-attachments/assets/ae2b10b4-0ac9-4875-a6c7-99b6b2d86caf" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Posts that have been merged are now displayed alongside other posts on the board. Previously, merged posts were excluded from the board view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->