### PR TITLE
Use Inertia::location() instead of redirect()->intended() so that

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -28,13 +28,13 @@ class AuthenticatedSessionController extends Controller
     /**
      * Handle an incoming authentication request.
      */
-    public function store(LoginRequest $request): RedirectResponse
+    public function store(LoginRequest $request): \Symfony\Component\HttpFoundation\Response
     {
         $request->authenticate();
 
         $request->session()->regenerate();
 
-        return redirect()->intended(RouteServiceProvider::HOME);
+        return Inertia::location(RouteServiceProvider::HOME);
     }
 
     /**


### PR DESCRIPTION
after login the browser performs a full page reload. This ensures the blade @routes directive re-runs for the authenticated user, populating window.Ziggy with admin routes — preventing the blank page caused by route('admin.feedbacks.index') throwing when admin routes are missing from the guest-only Ziggy config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated authentication session handling to use an alternative response mechanism for post-login navigation, improving integration with the frontend framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->