### PR TITLE
feat(billing): add Freemius SaaS premium gating

### DIFF
--- a/app/Http/Controllers/Admin/BillingController.php
+++ b/app/Http/Controllers/Admin/BillingController.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\License;
+use App\Services\Freemius\FreemiusService;
+use App\Services\Freemius\PremiumFeature;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class BillingController extends Controller
+{
+    public function __construct(private readonly FreemiusService $freemius)
+    {
+    }
+
+    /**
+     * Show the billing / upgrade page with the embedded checkout config.
+     */
+    public function index(): Response
+    {
+        $license = License::query()->active()->latest()->first();
+
+        return Inertia::render('Admin/Billing/Index', [
+            'checkout' => $this->freemius->checkoutConfig(),
+            'saasEnabled' => $this->freemius->saasEnabled(),
+            'hasActiveLicense' => $this->freemius->hasActiveLicense(),
+            'features' => collect(PremiumFeature::all())
+                ->map(fn ($meta, $key) => array_merge($meta, ['key' => $key]))
+                ->values()
+                ->all(),
+            'license' => $license ? [
+                'plan_title' => $license->plan_title,
+                'plan_id' => $license->plan_id,
+                'status' => $license->status,
+                'expiration' => $license->expiration?->toIso8601String(),
+            ] : null,
+        ]);
+    }
+
+    /**
+     * Record a purchase reported by the embedded Freemius checkout overlay.
+     */
+    public function activate(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'purchase' => ['required', 'array'],
+        ]);
+
+        $license = $this->freemius->recordPurchase($validated['purchase']);
+
+        if (! $license) {
+            return back()->with('error', 'We could not read the purchase details. Please contact support.');
+        }
+
+        return redirect()
+            ->route('admin.billing.index')
+            ->with('success', 'Your purchase was recorded. Premium features are now unlocked.');
+    }
+}

--- a/app/Http/Controllers/Api/FreemiusWebhookController.php
+++ b/app/Http/Controllers/Api/FreemiusWebhookController.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Services\Freemius\FreemiusService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class FreemiusWebhookController extends Controller
+{
+    public function __construct(private readonly FreemiusService $freemius)
+    {
+    }
+
+    /**
+     * Receive and process a Freemius webhook event.
+     *
+     * Authenticity is verified with the product secret key via the
+     * X-Signature header (HMAC-SHA256 of the raw body).
+     */
+    public function handle(Request $request): JsonResponse
+    {
+        $rawBody = $request->getContent();
+        $signature = $request->header('X-Signature');
+
+        if (! $this->freemius->verifyWebhookSignature($rawBody, $signature)) {
+            return response()->json(['message' => 'Invalid signature'], 401);
+        }
+
+        $payload = json_decode($rawBody, true);
+
+        if (! is_array($payload)) {
+            return response()->json(['message' => 'Invalid payload'], 422);
+        }
+
+        try {
+            $this->freemius->handleWebhook($payload);
+        } catch (\Throwable $e) {
+            Log::error('Freemius webhook processing failed', [
+                'type' => $payload['type'] ?? null,
+                'error' => $e->getMessage(),
+            ]);
+
+            return response()->json(['message' => 'Processing error'], 500);
+        }
+
+        return response()->json(['message' => 'ok']);
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -67,5 +67,6 @@ class Kernel extends HttpKernel
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         'admin' => \App\Http\Middleware\AdminOnly::class,
+        'premium' => \App\Http\Middleware\EnsurePremium::class,
     ];
 }

--- a/app/Http/Middleware/EnsurePremium.php
+++ b/app/Http/Middleware/EnsurePremium.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Services\Freemius\FreemiusService;
+use App\Services\Freemius\PremiumFeature;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsurePremium
+{
+    public function __construct(private readonly FreemiusService $freemius)
+    {
+    }
+
+    /**
+     * Block access to a premium feature unless the install holds an active
+     * Freemius license (or SaaS mode is disabled).
+     */
+    public function handle(Request $request, Closure $next, string $feature): Response
+    {
+        if ($this->freemius->canUse($feature)) {
+            return $next($request);
+        }
+
+        $label = PremiumFeature::all()[$feature]['label'] ?? 'This feature';
+        $message = "{$label} is a premium feature. Please upgrade to unlock it.";
+
+        if ($request->expectsJson()) {
+            abort(403, $message);
+        }
+
+        return redirect()
+            ->route('admin.billing.index')
+            ->with('error', $message);
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -9,6 +9,7 @@ use Inertia\Middleware;
 use App\Facades\Settings;
 use Tightenco\Ziggy\Ziggy;
 use Illuminate\Http\Request;
+use App\Services\Freemius\FreemiusService;
 
 class HandleInertiaRequests extends Middleware
 {
@@ -44,6 +45,10 @@ class HandleInertiaRequests extends Middleware
             'success' => fn () => $request->session()->get('success'),
             'error' => fn () => $request->session()->get('error'),
             'siteSettings' => Settings::all(),
+            'premium' => fn () => [
+                'saasEnabled' => app(FreemiusService::class)->saasEnabled(),
+                'features' => app(FreemiusService::class)->featureAvailability(),
+            ],
             'boards' => Board::getCachedPublicBoards(),
             'ziggy' => fn () => [
                 ...(new Ziggy())->toArray(),

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class License extends Model
+{
+    protected $fillable = [
+        'provider',
+        'license_id',
+        'plan_id',
+        'plan_title',
+        'pricing_id',
+        'freemius_user_id',
+        'install_id',
+        'subscription_id',
+        'status',
+        'is_active',
+        'expiration',
+        'data',
+    ];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+        'expiration' => 'datetime',
+        'data' => 'array',
+    ];
+
+    /**
+     * Scope to currently active (non-expired, non-cancelled) licenses.
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('is_active', true)
+            ->where(function (Builder $q) {
+                $q->whereNull('expiration')
+                    ->orWhere('expiration', '>', now());
+            });
+    }
+
+    /**
+     * Whether this individual license currently grants premium access.
+     */
+    public function isActive(): bool
+    {
+        if (! $this->is_active) {
+            return false;
+        }
+
+        return $this->expiration === null || $this->expiration->isFuture();
+    }
+}

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -129,6 +129,43 @@ class Setting extends Model
                 ],
             ],
 
+            // Billing / Freemius SaaS Group
+            'billing' => [
+                'label' => 'Billing',
+                'settings' => [
+                    'freemius_enabled' => [
+                        'type' => 'boolean',
+                        'label' => 'Enable SaaS Mode',
+                        'description' => 'Gate premium features behind an active Freemius license. When off, all features are unlocked.',
+                        'default' => false,
+                    ],
+                    'freemius_product_id' => [
+                        'type' => 'string',
+                        'label' => 'Freemius Product ID',
+                        'description' => 'The Product (Plugin) ID from your Freemius Developer Dashboard.',
+                        'default' => '',
+                    ],
+                    'freemius_public_key' => [
+                        'type' => 'string',
+                        'label' => 'Freemius Public Key',
+                        'description' => 'The public key used to load the embedded checkout.',
+                        'default' => '',
+                    ],
+                    'freemius_secret_key' => [
+                        'type' => 'password',
+                        'label' => 'Freemius Secret Key',
+                        'description' => 'The secret key used to verify webhooks. Keep this private.',
+                        'default' => '',
+                    ],
+                    'freemius_plan_id' => [
+                        'type' => 'string',
+                        'label' => 'Premium Plan ID',
+                        'description' => 'The Freemius Plan ID customers purchase to unlock premium features.',
+                        'default' => '',
+                    ],
+                ],
+            ],
+
             // Links Settings Group
             'links' => [
                 'label' => 'Links',

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Services\Freemius\FreemiusService;
 use App\Services\SettingService;
 use Illuminate\Support\ServiceProvider;
 
@@ -16,6 +17,10 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->app->singleton(SettingService::class, function ($app) {
             return new SettingService();
+        });
+
+        $this->app->singleton(FreemiusService::class, function ($app) {
+            return new FreemiusService();
         });
     }
 

--- a/app/Services/Freemius/FreemiusService.php
+++ b/app/Services/Freemius/FreemiusService.php
@@ -1,0 +1,330 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Freemius;
+
+use App\Facades\Settings;
+use App\Models\License;
+use Carbon\Carbon;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Encapsulates everything Freemius-specific: reading admin-managed config,
+ * building the embedded checkout configuration, verifying webhook
+ * authenticity, persisting the license snapshot, and answering the single
+ * question the rest of the app cares about — "is premium unlocked?".
+ */
+class FreemiusService
+{
+    private const LICENSE_CACHE_KEY = 'freemius_license_active';
+
+    /**
+     * Event type fragments that should grant / revoke premium access.
+     */
+    private const ACTIVATING_EVENTS = [
+        'license.created', 'license.updated', 'license.activated', 'license.extended',
+        'subscription.created', 'payment.created', 'install.activated',
+        'install.trial.started', 'after.purchase',
+    ];
+
+    private const DEACTIVATING_EVENTS = [
+        'license.cancelled', 'license.expired', 'license.deleted', 'license.deactivated',
+        'subscription.cancelled', 'install.deactivated', 'install.trial.expired',
+        'install.uninstalled',
+    ];
+
+    public function isEnabled(): bool
+    {
+        return (bool) Settings::get('freemius_enabled', false);
+    }
+
+    public function isConfigured(): bool
+    {
+        return ! empty($this->productId()) && ! empty($this->publicKey());
+    }
+
+    /**
+     * SaaS gating is only active when the admin has both enabled it and
+     * supplied the credentials needed to actually sell/verify licenses.
+     */
+    public function saasEnabled(): bool
+    {
+        return $this->isEnabled() && $this->isConfigured();
+    }
+
+    public function productId(): ?string
+    {
+        $value = Settings::get('freemius_product_id');
+
+        return $value !== null && $value !== '' ? (string) $value : null;
+    }
+
+    public function publicKey(): ?string
+    {
+        $value = Settings::get('freemius_public_key');
+
+        return $value !== null && $value !== '' ? (string) $value : null;
+    }
+
+    public function secretKey(): ?string
+    {
+        $value = Settings::get('freemius_secret_key');
+
+        return $value !== null && $value !== '' ? (string) $value : null;
+    }
+
+    public function planId(): ?string
+    {
+        $value = Settings::get('freemius_plan_id');
+
+        return $value !== null && $value !== '' ? (string) $value : null;
+    }
+
+    /**
+     * Configuration handed to the frontend to bootstrap FS.Checkout.
+     *
+     * @return array<string, mixed>
+     */
+    public function checkoutConfig(): array
+    {
+        return [
+            'enabled' => $this->saasEnabled(),
+            'configured' => $this->isConfigured(),
+            'product_id' => $this->productId(),
+            'public_key' => $this->publicKey(),
+            'plan_id' => $this->planId(),
+        ];
+    }
+
+    /**
+     * Whether the install currently holds an active premium license.
+     */
+    public function hasActiveLicense(): bool
+    {
+        return Cache::rememberForever(
+            self::LICENSE_CACHE_KEY,
+            fn () => License::query()->active()->exists()
+        );
+    }
+
+    /**
+     * Can the install use the given (possibly premium) feature right now?
+     *
+     * - Unknown / non-premium features are always allowed.
+     * - When SaaS mode is off, everything is unlocked (open-source mode).
+     * - Otherwise an active license is required.
+     */
+    public function canUse(string $feature): bool
+    {
+        if (! PremiumFeature::exists($feature)) {
+            return true;
+        }
+
+        if (! $this->saasEnabled()) {
+            return true;
+        }
+
+        return $this->hasActiveLicense();
+    }
+
+    /**
+     * Map of every premium feature to whether it is currently unlocked,
+     * shared with the frontend for conditional rendering.
+     *
+     * @return array<string, bool>
+     */
+    public function featureAvailability(): array
+    {
+        $result = [];
+
+        foreach (PremiumFeature::keys() as $feature) {
+            $result[$feature] = $this->canUse($feature);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Verify a webhook request body against the X-Signature header using the
+     * product secret key (HMAC-SHA256, hex), timing-safe.
+     */
+    public function verifyWebhookSignature(string $rawBody, ?string $signature): bool
+    {
+        $secret = $this->secretKey();
+
+        if (empty($secret) || empty($signature)) {
+            return false;
+        }
+
+        $expected = hash_hmac('sha256', $rawBody, $secret);
+
+        return hash_equals($expected, $signature);
+    }
+
+    /**
+     * Process a verified webhook payload, updating the local license state.
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    public function handleWebhook(array $payload): void
+    {
+        $type = (string) Arr::get($payload, 'type', '');
+        $objects = (array) Arr::get($payload, 'objects', []);
+
+        $license = $this->extractLicense($objects);
+
+        if ($license === null) {
+            return;
+        }
+
+        $isActive = $this->isActivatingEvent($type)
+            ? true
+            : ($this->isDeactivatingEvent($type) ? false : $this->licenseLooksActive($license));
+
+        $this->storeLicense($license, $type, $isActive);
+    }
+
+    /**
+     * Record a purchase reported by the embedded checkout (admin-initiated).
+     *
+     * @param  array<string, mixed>  $response  The FS.Checkout purchaseCompleted payload.
+     */
+    public function recordPurchase(array $response): ?License
+    {
+        $license = $this->extractLicense($response);
+
+        if ($license === null) {
+            return null;
+        }
+
+        return $this->storeLicense($license, 'checkout.purchase', $this->licenseLooksActive($license));
+    }
+
+    /**
+     * Persist (insert/update) a normalized license and refresh the gate cache.
+     *
+     * @param  array<string, mixed>  $license
+     */
+    private function storeLicense(array $license, string $source, bool $isActive): License
+    {
+        $licenseId = (string) ($license['id'] ?? '');
+
+        $record = License::query()->updateOrCreate(
+            ['provider' => 'freemius', 'license_id' => $licenseId],
+            [
+                'plan_id' => isset($license['plan_id']) ? (string) $license['plan_id'] : null,
+                'plan_title' => $license['plan_title'] ?? null,
+                'pricing_id' => isset($license['pricing_id']) ? (string) $license['pricing_id'] : null,
+                'freemius_user_id' => isset($license['user_id']) ? (string) $license['user_id'] : null,
+                'install_id' => isset($license['install_id']) ? (string) $license['install_id'] : null,
+                'subscription_id' => isset($license['subscription_id']) ? (string) $license['subscription_id'] : null,
+                'status' => $isActive ? 'active' : 'inactive',
+                'is_active' => $isActive,
+                'expiration' => $this->parseExpiration($license['expiration'] ?? null),
+                'data' => ['source' => $source, 'license' => $license],
+            ]
+        );
+
+        $this->forgetCache();
+
+        return $record;
+    }
+
+    /**
+     * Pull a normalized license array out of any of the shapes Freemius uses
+     * (checkout response, webhook `objects`, or a bare license object).
+     *
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>|null
+     */
+    private function extractLicense(array $data): ?array
+    {
+        $candidate = $data['license']
+            ?? $data['purchase']
+            ?? (isset($data['id'], $data['plan_id']) ? $data : null);
+
+        if (! is_array($candidate)) {
+            return null;
+        }
+
+        // A purchase/payment object references the license rather than being one.
+        if (! isset($candidate['id']) && isset($candidate['license_id'])) {
+            $candidate['id'] = $candidate['license_id'];
+        }
+
+        if (empty($candidate['id'])) {
+            return null;
+        }
+
+        // Fold subscription/install context in when present alongside the license.
+        if (isset($data['subscription']['id'])) {
+            $candidate['subscription_id'] = $data['subscription']['id'];
+        }
+        if (isset($data['install']['id'])) {
+            $candidate['install_id'] = $data['install']['id'];
+        }
+        if (isset($data['plan']['title'])) {
+            $candidate['plan_title'] = $data['plan']['title'];
+        }
+
+        return $candidate;
+    }
+
+    /**
+     * @param  array<string, mixed>  $license
+     */
+    private function licenseLooksActive(array $license): bool
+    {
+        if (array_key_exists('is_cancelled', $license) && $license['is_cancelled']) {
+            return false;
+        }
+
+        $expiration = $this->parseExpiration($license['expiration'] ?? null);
+
+        return $expiration === null || $expiration->isFuture();
+    }
+
+    private function parseExpiration(mixed $value): ?Carbon
+    {
+        if (empty($value)) {
+            return null;
+        }
+
+        try {
+            return Carbon::parse((string) $value);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private function isActivatingEvent(string $type): bool
+    {
+        return $this->matchesEvent($type, self::ACTIVATING_EVENTS);
+    }
+
+    private function isDeactivatingEvent(string $type): bool
+    {
+        return $this->matchesEvent($type, self::DEACTIVATING_EVENTS);
+    }
+
+    /**
+     * @param  array<int, string>  $events
+     */
+    private function matchesEvent(string $type, array $events): bool
+    {
+        foreach ($events as $event) {
+            if ($type === $event || str_starts_with($type, $event)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function forgetCache(): void
+    {
+        Cache::forget(self::LICENSE_CACHE_KEY);
+    }
+}

--- a/app/Services/Freemius/PremiumFeature.php
+++ b/app/Services/Freemius/PremiumFeature.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Freemius;
+
+/**
+ * Registry of features that require an active Freemius license when SaaS
+ * mode is enabled. Add a constant here and an entry in all() to gate a new
+ * feature; it will automatically be enforced by the `premium` middleware and
+ * exposed to the frontend through the shared Inertia props.
+ */
+class PremiumFeature
+{
+    public const INTEGRATIONS = 'integrations';
+
+    public const AI_ASSIST = 'ai_assist';
+
+    /**
+     * All gated features with their display metadata.
+     *
+     * @return array<string, array{label: string, description: string}>
+     */
+    public static function all(): array
+    {
+        return [
+            self::INTEGRATIONS => [
+                'label' => 'Integrations',
+                'description' => 'Connect IdeaBox to GitHub and other external tools.',
+            ],
+            self::AI_ASSIST => [
+                'label' => 'AI Assist',
+                'description' => 'Generate feature descriptions and summaries with AI.',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function keys(): array
+    {
+        return array_keys(self::all());
+    }
+
+    public static function exists(string $feature): bool
+    {
+        return array_key_exists($feature, self::all());
+    }
+}

--- a/database/migrations/2026_06_24_000000_create_licenses_table.php
+++ b/database/migrations/2026_06_24_000000_create_licenses_table.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Stores the Freemius license/subscription snapshot for the install.
+     * IdeaBox gates premium features on the presence of an active license.
+     */
+    public function up(): void
+    {
+        Schema::create('licenses', function (Blueprint $table) {
+            $table->id();
+            $table->string('provider')->default('freemius');
+            $table->string('license_id')->index();
+            $table->string('plan_id')->nullable();
+            $table->string('plan_title')->nullable();
+            $table->string('pricing_id')->nullable();
+            $table->string('freemius_user_id')->nullable();
+            $table->string('install_id')->nullable();
+            $table->string('subscription_id')->nullable();
+            $table->string('status')->default('active');
+            $table->boolean('is_active')->default(true);
+            $table->timestamp('expiration')->nullable();
+            $table->json('data')->nullable();
+            $table->timestamps();
+
+            $table->unique(['provider', 'license_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('licenses');
+    }
+};

--- a/docs/freemius-saas.md
+++ b/docs/freemius-saas.md
@@ -1,0 +1,53 @@
+# Freemius SaaS / Premium Gating
+
+IdeaBox can run as a SaaS product where premium features are unlocked by
+purchasing a [Freemius](https://freemius.com) license. Everything is
+configured by the system admin from the admin panel — no `.env` changes or
+code edits are required to go live.
+
+## How it works
+
+- **SaaS mode is opt-in.** While it is disabled, every feature is available
+  for free (the standard open-source behaviour). Turning it on gates the
+  premium features behind an active license.
+- **Premium features** are defined in
+  `App\Services\Freemius\PremiumFeature`. Out of the box these are:
+  - `integrations` – GitHub and other external integrations.
+  - `ai_assist` – AI-generated feature descriptions.
+- A feature is **unlocked** when SaaS mode is off, **or** the install holds an
+  active Freemius license.
+
+## Admin setup
+
+1. Create a Product in the [Freemius Developer Dashboard](https://dashboard.freemius.com)
+   and add a paid Plan.
+2. In IdeaBox, go to **Settings → Billing** and fill in:
+   - **Enable SaaS Mode** – turn gating on.
+   - **Freemius Product ID** – the Product (Plugin) ID.
+   - **Freemius Public Key** – used to load the embedded checkout.
+   - **Freemius Secret Key** – used to verify webhooks (keep private).
+   - **Premium Plan ID** – the plan customers buy to unlock premium.
+3. In Freemius, add a webhook pointing at:
+   `https://your-domain.com/api/webhooks/freemius`
+
+## Purchasing
+
+The **Billing** page hosts an embedded Freemius Checkout overlay. When the
+admin completes a purchase, the returned license is recorded and premium
+features unlock immediately. The Freemius webhook is the authoritative source
+of truth and keeps the license state in sync (renewals, cancellations,
+expirations).
+
+## Gating a new feature
+
+1. Add a constant and an `all()` entry to `PremiumFeature`.
+2. Protect routes with the `premium` middleware, e.g.
+   `->middleware('premium:my_feature')`.
+3. The feature's availability is shared with the frontend via the
+   `premium.features` Inertia prop for conditional rendering.
+
+## Webhook verification
+
+Webhooks are authenticated with the product secret key. The raw request body
+is hashed with HMAC-SHA256 and compared (timing-safe) against the
+`X-Signature` header, exactly as described in the Freemius documentation.

--- a/resources/js/Components/Settings/SettingInput.tsx
+++ b/resources/js/Components/Settings/SettingInput.tsx
@@ -107,6 +107,16 @@ export default function SettingInput({
     case 'text':
       return <Textarea value={value || ''} onChange={onChange} rows={3} />;
 
+    case 'password':
+      return (
+        <TextField
+          type="password"
+          value={value || ''}
+          onChange={onChange}
+          autoComplete="new-password"
+        />
+      );
+
     default:
       return <TextField type="text" value={value || ''} onChange={onChange} />;
   }

--- a/resources/js/Layouts/AuthenticatedLayout.tsx
+++ b/resources/js/Layouts/AuthenticatedLayout.tsx
@@ -75,6 +75,13 @@ export default function Authenticated({
                 >
                   Settings
                 </NavLink>
+
+                <NavLink
+                  href={route('admin.billing.index')}
+                  active={route().current('admin.billing.*')}
+                >
+                  Billing
+                </NavLink>
               </div>
             </div>
 
@@ -215,6 +222,13 @@ export default function Authenticated({
               active={route().current('admin.settings.*')}
             >
               Settings
+            </ResponsiveNavLink>
+
+            <ResponsiveNavLink
+              href={route('admin.billing.index')}
+              active={route().current('admin.billing.*')}
+            >
+              Billing
             </ResponsiveNavLink>
           </div>
 

--- a/resources/js/Pages/Admin/Billing/Index.tsx
+++ b/resources/js/Pages/Admin/Billing/Index.tsx
@@ -1,0 +1,258 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Head, Link, router, usePage } from '@inertiajs/react';
+import { Button, Notice } from '@wedevs/tail-react';
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { PageProps } from '@/types';
+import { CheckIcon, LockClosedIcon } from '@heroicons/react/24/solid';
+
+const CHECKOUT_SCRIPT = 'https://checkout.freemius.com/checkout.min.js';
+
+interface CheckoutConfig {
+  enabled: boolean;
+  configured: boolean;
+  product_id: string | null;
+  public_key: string | null;
+  plan_id: string | null;
+}
+
+interface Feature {
+  key: string;
+  label: string;
+  description: string;
+}
+
+interface LicenseInfo {
+  plan_title: string | null;
+  plan_id: string | null;
+  status: string;
+  expiration: string | null;
+}
+
+interface Props extends PageProps {
+  checkout: CheckoutConfig;
+  saasEnabled: boolean;
+  hasActiveLicense: boolean;
+  features: Feature[];
+  license: LicenseInfo | null;
+}
+
+export default function BillingIndex({
+  checkout,
+  saasEnabled,
+  hasActiveLicense,
+  features,
+  license,
+}: Props) {
+  const { appName } = usePage<PageProps>().props;
+  const [scriptReady, setScriptReady] = useState(false);
+  const [processing, setProcessing] = useState(false);
+  const handlerRef = useRef<any>(null);
+
+  // Lazy-load the Freemius checkout widget once we know it's needed.
+  useEffect(() => {
+    if (!checkout.configured) {
+      return;
+    }
+
+    if ((window as any).FS) {
+      setScriptReady(true);
+      return;
+    }
+
+    const existing = document.querySelector(
+      `script[src="${CHECKOUT_SCRIPT}"]`,
+    );
+    if (existing) {
+      existing.addEventListener('load', () => setScriptReady(true));
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = CHECKOUT_SCRIPT;
+    script.async = true;
+    script.onload = () => setScriptReady(true);
+    document.body.appendChild(script);
+  }, [checkout.configured]);
+
+  const openCheckout = () => {
+    const FS = (window as any).FS;
+    if (!FS || !checkout.product_id || !checkout.public_key) {
+      return;
+    }
+
+    if (!handlerRef.current) {
+      handlerRef.current = FS.Checkout.configure({
+        plugin_id: checkout.product_id,
+        public_key: checkout.public_key,
+      });
+    }
+
+    handlerRef.current.open({
+      name: appName,
+      plan_id: checkout.plan_id || undefined,
+      licenses: 1,
+      purchaseCompleted: (response: any) => {
+        setProcessing(true);
+        router.post(
+          route('admin.billing.activate'),
+          { purchase: response },
+          {
+            preserveScroll: true,
+            onFinish: () => setProcessing(false),
+          },
+        );
+      },
+    });
+  };
+
+  return (
+    <AuthenticatedLayout
+      header={
+        <h2 className="text-xl font-semibold leading-tight text-gray-800 dark:text-gray-100">
+          Billing
+        </h2>
+      }
+    >
+      <Head title="Billing" />
+
+      <div className="space-y-6">
+        {/* Current plan status */}
+        <div className="overflow-hidden rounded-lg bg-white shadow dark:bg-gray-800">
+          <div className="border-b border-gray-200 p-6 dark:border-gray-700">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="text-lg font-medium text-gray-900 dark:text-white">
+                  {hasActiveLicense ? 'Premium' : 'Free'} Plan
+                </h3>
+                <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                  {hasActiveLicense
+                    ? `You have an active ${license?.plan_title ?? 'premium'} license. All premium features are unlocked.`
+                    : saasEnabled
+                      ? 'Upgrade to unlock premium features for your workspace.'
+                      : 'SaaS mode is disabled — every feature is currently unlocked for free.'}
+                </p>
+              </div>
+              {hasActiveLicense ? (
+                <span className="rounded bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900 dark:text-green-300">
+                  Active
+                </span>
+              ) : (
+                <span className="rounded bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800 dark:bg-gray-700 dark:text-gray-300">
+                  Free
+                </span>
+              )}
+            </div>
+
+            {hasActiveLicense && license?.expiration && (
+              <p className="mt-3 text-sm text-gray-500 dark:text-gray-400">
+                Renews / expires on{' '}
+                {new Date(license.expiration).toLocaleDateString()}.
+              </p>
+            )}
+          </div>
+
+          <div className="flex items-center justify-between gap-4 p-6">
+            {!saasEnabled && (
+              <Notice
+                type="info"
+                className="flex-1"
+                label={
+                  <>
+                    Enable SaaS Mode and add your Freemius credentials under{' '}
+                    <Link
+                      href={route('admin.settings.index', {
+                        group: 'billing',
+                      })}
+                      className="font-medium text-indigo-600 hover:underline dark:text-indigo-400"
+                    >
+                      Settings → Billing
+                    </Link>{' '}
+                    to start selling premium access.
+                  </>
+                }
+              />
+            )}
+
+            {saasEnabled && !checkout.configured && (
+              <Notice
+                type="warning"
+                className="flex-1"
+                label={
+                  <>
+                    Add your Freemius Product ID and Public Key under{' '}
+                    <Link
+                      href={route('admin.settings.index', {
+                        group: 'billing',
+                      })}
+                      className="font-medium text-indigo-600 hover:underline dark:text-indigo-400"
+                    >
+                      Settings → Billing
+                    </Link>
+                    .
+                  </>
+                }
+              />
+            )}
+
+            {saasEnabled && checkout.configured && !hasActiveLicense && (
+              <Button
+                variant="primary"
+                onClick={openCheckout}
+                loading={processing}
+                disabled={!scriptReady}
+              >
+                {scriptReady ? 'Upgrade to Premium' : 'Loading checkout…'}
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {/* Premium feature list */}
+        <div className="overflow-hidden rounded-lg bg-white shadow dark:bg-gray-800">
+          <div className="border-b border-gray-200 p-6 dark:border-gray-700">
+            <h3 className="text-lg font-medium text-gray-900 dark:text-white">
+              Premium Features
+            </h3>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+              These features require an active license when SaaS mode is
+              enabled.
+            </p>
+          </div>
+          <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+            {features.map((feature) => {
+              const unlocked = !saasEnabled || hasActiveLicense;
+              return (
+                <li
+                  key={feature.key}
+                  className="flex items-center gap-4 p-6"
+                >
+                  <span
+                    className={
+                      unlocked
+                        ? 'rounded-full bg-green-100 p-2 text-green-600 dark:bg-green-900 dark:text-green-300'
+                        : 'rounded-full bg-gray-100 p-2 text-gray-400 dark:bg-gray-700'
+                    }
+                  >
+                    {unlocked ? (
+                      <CheckIcon className="h-5 w-5" />
+                    ) : (
+                      <LockClosedIcon className="h-5 w-5" />
+                    )}
+                  </span>
+                  <div>
+                    <p className="font-medium text-gray-900 dark:text-white">
+                      {feature.label}
+                    </p>
+                    <p className="text-sm text-gray-600 dark:text-gray-400">
+                      {feature.description}
+                    </p>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </div>
+    </AuthenticatedLayout>
+  );
+}

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -32,9 +32,15 @@ export type PageProps<
   appLogo: string;
   boards: BoardType[];
   siteSettings?: SiteSettings;
+  premium?: PremiumProps;
   success?: string;
   error?: string;
 };
+
+export interface PremiumProps {
+  saasEnabled: boolean;
+  features: Record<string, boolean>;
+}
 
 export interface PaginatedLink {
   url: string;

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\GitHubWebhookController;
+use App\Http\Controllers\Api\FreemiusWebhookController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -21,3 +22,4 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 
 // Webhook routes
 Route::post('/webhooks/github', [GitHubWebhookController::class, 'handle'])->name('api.webhooks.github');
+Route::post('/webhooks/freemius', [FreemiusWebhookController::class, 'handle'])->name('api.webhooks.freemius');

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,7 @@ use App\Http\Controllers\Admin\GitHub\GitHubRepositoryController;
 use App\Http\Controllers\Admin\BoardController as AdminBoardController;
 use App\Http\Controllers\Admin\CommentController as AdminCommentController;
 use App\Http\Controllers\Admin\SettingController;
+use App\Http\Controllers\Admin\BillingController;
 use App\Http\Controllers\Frontend\SubscriptionController;
 
 /*
@@ -50,6 +51,10 @@ Route::prefix('admin')->middleware('auth', 'verified', 'admin')->group(function 
     Route::get('/settings', [SettingController::class, 'index'])->name('admin.settings.index');
     Route::post('/settings', [SettingController::class, 'update'])->name('admin.settings.update');
 
+    // Billing / Freemius SaaS
+    Route::get('/billing', [BillingController::class, 'index'])->name('admin.billing.index');
+    Route::post('/billing/activate', [BillingController::class, 'activate'])->name('admin.billing.activate');
+
     Route::get('/feedbacks/search', [FeedbackController::class, 'search'])->name('admin.feedbacks.search');
     Route::get('/feedbacks', [FeedbackController::class, 'index'])->name('admin.feedbacks.index');
     Route::get('/feedbacks/{post}', [FeedbackController::class, 'show'])->name('admin.feedbacks.show');
@@ -60,7 +65,9 @@ Route::prefix('admin')->middleware('auth', 'verified', 'admin')->group(function 
     Route::delete('/feedbacks/{post}', [FeedbackController::class, 'destroy'])->name('admin.feedbacks.destroy');
     Route::post('/feedbacks/{post}/merge', [MergeController::class, 'merge'])->name('admin.feedbacks.merge');
 
-    Route::post('/api/generate-feature-description', [FeedbackController::class, 'generateDescription'])->name('api.generate-feature-description');
+    Route::post('/api/generate-feature-description', [FeedbackController::class, 'generateDescription'])
+        ->middleware('premium:ai_assist')
+        ->name('api.generate-feature-description');
 
     Route::delete('/comment/{comment}', [AdminCommentController::class, 'destroy'])->name('admin.comments.destroy');
 
@@ -85,8 +92,10 @@ Route::prefix('admin')->middleware('auth', 'verified', 'admin')->group(function 
 
     Route::get('/search-users', [UserSearchController::class, 'search'])->name('admin.users.search');
 
-    // Integrations main page
-    Route::get('/integrations', [IntegrationsController::class, 'index'])->name('admin.integrations.index');
+    // Integrations main page (premium-gated)
+    Route::get('/integrations', [IntegrationsController::class, 'index'])
+        ->middleware('premium:integrations')
+        ->name('admin.integrations.index');
 });
 
 Route::middleware(['auth', 'verified'])->group(function () {
@@ -106,7 +115,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
 Route::get('posts/{post}/unsubscribe', [SubscriptionController::class, 'unsubscribe'])->name('post.unsubscribe');
 
 // GitHub Integration Routes - Updated to use the new controllers
-Route::middleware(['auth', 'admin', 'verified'])->prefix('admin/integrations/github')->name('admin.integrations.github.')->group(function () {
+Route::middleware(['auth', 'admin', 'verified', 'premium:integrations'])->prefix('admin/integrations/github')->name('admin.integrations.github.')->group(function () {
     // Account management
     Route::get('/', [GitHubAccountController::class, 'settings'])->name('settings');
     Route::post('/connect', [GitHubAccountController::class, 'connect'])->name('connect');

--- a/tests/Feature/Freemius/FreemiusWebhookTest.php
+++ b/tests/Feature/Freemius/FreemiusWebhookTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Facades\Settings;
+use App\Models\License;
+use App\Services\Freemius\FreemiusService;
+
+const WEBHOOK_SECRET = 'sk_webhook_secret';
+
+beforeEach(function () {
+    Settings::set('freemius_enabled', true);
+    Settings::set('freemius_product_id', '12345');
+    Settings::set('freemius_public_key', 'pk_test');
+    Settings::set('freemius_secret_key', WEBHOOK_SECRET);
+    app(FreemiusService::class)->forgetCache();
+});
+
+function postWebhook(array $payload, ?string $secret = WEBHOOK_SECRET): \Illuminate\Testing\TestResponse
+{
+    $body = json_encode($payload);
+    $signature = $secret !== null ? hash_hmac('sha256', $body, $secret) : '';
+
+    return test()->call(
+        'POST',
+        route('api.webhooks.freemius'),
+        [],
+        [],
+        [],
+        ['HTTP_X_SIGNATURE' => $signature, 'CONTENT_TYPE' => 'application/json'],
+        $body
+    );
+}
+
+it('rejects a webhook with an invalid signature', function () {
+    $response = test()->call(
+        'POST',
+        route('api.webhooks.freemius'),
+        [],
+        [],
+        [],
+        ['HTTP_X_SIGNATURE' => 'deadbeef', 'CONTENT_TYPE' => 'application/json'],
+        json_encode(['type' => 'license.created', 'objects' => ['license' => ['id' => 1]]])
+    );
+
+    $response->assertStatus(401);
+    expect(License::count())->toBe(0);
+});
+
+it('activates a license from a verified license.created webhook', function () {
+    $response = postWebhook([
+        'type' => 'license.created',
+        'objects' => [
+            'license' => ['id' => 9001, 'plan_id' => 678, 'expiration' => null],
+            'plan' => ['title' => 'Premium'],
+        ],
+    ]);
+
+    $response->assertOk();
+
+    $license = License::first();
+    expect($license)->not->toBeNull();
+    expect($license->license_id)->toBe('9001');
+    expect($license->plan_title)->toBe('Premium');
+    expect($license->is_active)->toBeTrue();
+    expect(app(FreemiusService::class)->hasActiveLicense())->toBeTrue();
+});
+
+it('deactivates a license on a cancellation webhook', function () {
+    postWebhook([
+        'type' => 'license.created',
+        'objects' => ['license' => ['id' => 9001, 'expiration' => null]],
+    ])->assertOk();
+
+    expect(app(FreemiusService::class)->hasActiveLicense())->toBeTrue();
+
+    postWebhook([
+        'type' => 'subscription.cancelled',
+        'objects' => ['license' => ['id' => 9001]],
+    ])->assertOk();
+
+    expect(License::first()->is_active)->toBeFalse();
+    expect(app(FreemiusService::class)->hasActiveLicense())->toBeFalse();
+});
+
+it('respects an explicit expiration in the future', function () {
+    postWebhook([
+        'type' => 'license.updated',
+        'objects' => [
+            'license' => [
+                'id' => 5,
+                'expiration' => now()->addYear()->toDateTimeString(),
+            ],
+        ],
+    ])->assertOk();
+
+    expect(app(FreemiusService::class)->hasActiveLicense())->toBeTrue();
+});

--- a/tests/Feature/Freemius/PremiumGateTest.php
+++ b/tests/Feature/Freemius/PremiumGateTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Facades\Settings;
+use App\Models\License;
+use App\Models\User;
+use App\Services\Freemius\FreemiusService;
+use App\Services\Freemius\PremiumFeature;
+
+function enableSaas(): void
+{
+    Settings::set('freemius_enabled', true);
+    Settings::set('freemius_product_id', '12345');
+    Settings::set('freemius_public_key', 'pk_test');
+    Settings::set('freemius_secret_key', 'sk_test');
+    Settings::set('freemius_plan_id', '678');
+    app(FreemiusService::class)->forgetCache();
+}
+
+function activeLicense(): License
+{
+    $license = License::create([
+        'provider' => 'freemius',
+        'license_id' => 'lic_1',
+        'plan_id' => '678',
+        'status' => 'active',
+        'is_active' => true,
+        'expiration' => null,
+    ]);
+
+    app(FreemiusService::class)->forgetCache();
+
+    return $license;
+}
+
+it('unlocks every feature when SaaS mode is disabled', function () {
+    $freemius = app(FreemiusService::class);
+
+    expect($freemius->saasEnabled())->toBeFalse();
+    expect($freemius->canUse(PremiumFeature::INTEGRATIONS))->toBeTrue();
+    expect($freemius->canUse(PremiumFeature::AI_ASSIST))->toBeTrue();
+});
+
+it('locks premium features when SaaS is enabled without a license', function () {
+    enableSaas();
+    $freemius = app(FreemiusService::class);
+
+    expect($freemius->saasEnabled())->toBeTrue();
+    expect($freemius->hasActiveLicense())->toBeFalse();
+    expect($freemius->canUse(PremiumFeature::INTEGRATIONS))->toBeFalse();
+    expect($freemius->canUse(PremiumFeature::AI_ASSIST))->toBeFalse();
+});
+
+it('unlocks premium features when an active license exists', function () {
+    enableSaas();
+    activeLicense();
+    $freemius = app(FreemiusService::class);
+
+    expect($freemius->hasActiveLicense())->toBeTrue();
+    expect($freemius->canUse(PremiumFeature::INTEGRATIONS))->toBeTrue();
+});
+
+it('treats an expired license as inactive', function () {
+    enableSaas();
+    License::create([
+        'provider' => 'freemius',
+        'license_id' => 'lic_expired',
+        'is_active' => true,
+        'expiration' => now()->subDay(),
+    ]);
+    app(FreemiusService::class)->forgetCache();
+
+    expect(app(FreemiusService::class)->hasActiveLicense())->toBeFalse();
+});
+
+it('always allows features that are not in the premium registry', function () {
+    enableSaas();
+
+    expect(app(FreemiusService::class)->canUse('something_free'))->toBeTrue();
+});
+
+it('redirects to billing when an admin opens a locked integrations page', function () {
+    enableSaas();
+    $admin = User::factory()->create(['role' => 'admin']);
+
+    $this->actingAs($admin)
+        ->get(route('admin.integrations.index'))
+        ->assertRedirect(route('admin.billing.index'));
+});
+
+it('allows the integrations page once a license is active', function () {
+    enableSaas();
+    activeLicense();
+    $admin = User::factory()->create(['role' => 'admin']);
+
+    $this->actingAs($admin)
+        ->get(route('admin.integrations.index'))
+        ->assertOk();
+});
+
+it('blocks the AI generation route with 403 when locked', function () {
+    enableSaas();
+    $admin = User::factory()->create(['role' => 'admin']);
+
+    $this->actingAs($admin)
+        ->postJson(route('api.generate-feature-description'), ['title' => 'Test'])
+        ->assertForbidden();
+});


### PR DESCRIPTION
Introduce an opt-in SaaS mode that gates premium features behind an active Freemius license, configured entirely from the admin panel.

- Add a "Billing" settings group (enable flag, product/public/secret keys, plan id) managed via the existing admin Settings UI.
- Add FreemiusService for config, embedded-checkout config, webhook signature verification (HMAC-SHA256 of the raw body vs X-Signature) and license state; PremiumFeature registry drives what is gated.
- Persist license/subscription state in a new licenses table updated from verified webhooks and recorded checkout purchases.
- Gate integrations and AI-assist routes with an EnsurePremium middleware; share premium availability to the frontend via Inertia props.
- Add an admin Billing page with the embedded Freemius Checkout overlay, a Billing nav link, and a password input type for secret settings.
- Add feature tests for the premium gate and webhook handling, plus docs.

When SaaS mode is off, all features remain free (open-source behaviour).


Claude-Session: https://claude.ai/code/session_01KCYAdhHH9aXuoPqrewGEUh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Billing area for upgrading, viewing license status, and managing premium access.
  * Introduced premium feature indicators across the app, including locked/unlocked states.
  * Added support for receiving purchase and license updates from the billing provider.

* **Bug Fixes**
  * Premium-only pages and actions now properly redirect or block access when a license is missing or inactive.
  * License status now respects expiration dates and updates more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->